### PR TITLE
Update header and changelog with new pages

### DIFF
--- a/content/changelog/2022-08-new-team-page.md
+++ b/content/changelog/2022-08-new-team-page.md
@@ -1,0 +1,9 @@
+---
+title: New team page
+date: "2022-08-09"
+order: 1
+---
+
+A new [team page](https://gnomad.broadinstitute.org/team) centralizes information about the people who work on the gnomAD project. Pertinent information that was previously located on the About page has been moved to Teams, and additional details about the team have been added.
+
+<!-- end_excerpt -->

--- a/content/changelog/2022-08-update-policies-page.md
+++ b/content/changelog/2022-08-update-policies-page.md
@@ -1,0 +1,9 @@
+---
+title: Update policies page
+date: "2022-08-09"
+order: 2
+---
+
+The [policies page](https://gnomad.broadinstitute.org/policies), previously titled 'terms', has been updated to cover additional policies. New policies include, but are not limited to, data privacy, ethics, and open science.
+
+<!-- end_excerpt -->

--- a/src/components/header.js
+++ b/src/components/header.js
@@ -35,6 +35,11 @@ const Header = ({ siteTitle }) => {
             </a>
           </li>
           <li className="nav-item">
+            <a className="nav-link" href="https://gnomad.broadinstitute.org/team">
+              Team
+            </a>
+          </li>
+          <li className="nav-item">
             <Link className="nav-link" to="/">
               News
             </Link>
@@ -45,8 +50,8 @@ const Header = ({ siteTitle }) => {
             </a>
           </li>
           <li className="nav-item">
-            <a className="nav-link" href="https://gnomad.broadinstitute.org/terms">
-              Terms
+            <a className="nav-link" href="https://gnomad.broadinstitute.org/policies">
+              Policies
             </a>
           </li>
           <li className="nav-item">


### PR DESCRIPTION
Add `Team` to header, modify `Terms` to `Policies`

Add two brief changelog posts, one about the new Team page, one about the modifications to the Policies page

View a [preview here](https://gnomad.broadinstitute.org/news/preview/75/)