### PR TITLE
Modify header routes and order, add brief descriptions

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -2,7 +2,7 @@
 const config = {
   pathPrefix: process.env.PATH_PREFIX || "/news",
   siteMetadata: {
-    title: "gnomAD news",
+    title: "gnomAD browser",
     description: "Announcements from the gnomAD project",
     siteUrl: "https://gnomad.broadinstitute.org/news",
   },

--- a/src/components/header.js
+++ b/src/components/header.js
@@ -7,7 +7,7 @@ const Header = ({ siteTitle }) => {
   return (
     <header id="header">
       <h1 className="header-title">
-        <Link to="/">{siteTitle}</Link>
+        <Link to="https://gnomad.broadinstitute.org/">{siteTitle}</Link>
       </h1>
 
       <nav role="navigation">
@@ -25,11 +25,6 @@ const Header = ({ siteTitle }) => {
         </button>
         <ul id="nav-list" className={isExpanded ? "expanded" : undefined}>
           <li className="nav-item">
-            <a className="nav-link" href="https://gnomad.broadinstitute.org/">
-              Browser
-            </a>
-          </li>
-          <li className="nav-item">
             <a className="nav-link" href="https://gnomad.broadinstitute.org/about">
               About
             </a>
@@ -42,6 +37,11 @@ const Header = ({ siteTitle }) => {
           <li className="nav-item">
             <Link className="nav-link" to="/">
               News
+            </Link>
+          </li>
+          <li className="nav-item">
+            <Link className="nav-link" to="/changelog">
+              Changelog
             </Link>
           </li>
           <li className="nav-item">
@@ -63,11 +63,6 @@ const Header = ({ siteTitle }) => {
             <a className="nav-link" href="https://gnomad.broadinstitute.org/feedback">
               Feedback
             </a>
-          </li>
-          <li className="nav-item">
-            <Link className="nav-link" to="/changelog">
-              Changelog
-            </Link>
           </li>
           <li className="nav-item">
             <a className="nav-link" href="https://gnomad.broadinstitute.org/help">

--- a/src/components/list.js
+++ b/src/components/list.js
@@ -8,6 +8,12 @@ const ArticleList = ({ heading, posts, extraSidebarContent }) => {
   return (
     <div className="article-list">
       {heading && <h1>{heading}</h1>}
+      <h1>News</h1>
+      <p>
+        The news page highlights new features, versions, or other major announcements. See our{" "}
+        <Link to="/changelog">changelog</Link> for all changes to gnomAD, including minor ones.
+      </p>
+      <br />
       <div className="article-list-inner">
         {posts.map(({ node }) => {
           const title = node.frontmatter.title || node.fields.slug;

--- a/src/pages/changelog.js
+++ b/src/pages/changelog.js
@@ -9,6 +9,7 @@ const ChangelogPage = ({ data }) => {
     <Layout title="Changelog">
       <div className="article-list no-sidebar">
         <h1>Changelog</h1>
+        <p>The changelog contains a record of all changes made to gnomAD, small or large.</p>
         <div className="article-list-inner">
           {data.allMarkdownRemark.edges.map(({ node }) => {
             const title = node.frontmatter.title || node.fields.slug;

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -9,7 +9,7 @@ import RSSIcon from "../components/rss-icon";
 
 const BlogIndex = ({ data }) => {
   return (
-    <Layout title="Home">
+    <Layout title="News">
       <ArticleList
         posts={data.allMarkdownRemark.edges}
         extraSidebarContent={


### PR DESCRIPTION
Resolves #76 

- `gnomAD News` is changed to `gnomAD browser` and now redirects to the browser home page
  - `Browser` has been removed from the header, as the standard `gnomAD browser` is now the route to the gnomAD home page
- `Changelog` has been moved to be before `News` in the header
- `Changelog` and `News` both have gained brief descriptions on their respective pages, clarifying the difference between the two pages.

View a [preview here](https://gnomad.broadinstitute.org/news/preview/77/)