### PR TITLE
Remove hiring banner

### DIFF
--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -45,12 +45,7 @@ const Banner = styled.div`
   }
 `;
 
-const BANNER_CONTENT = (
-  <>
-    We&apos;re hiring! {" • "}
-    <ExternalLink href="https://broad.io/gnomad-cs">Computational scientist</ExternalLink>
-  </>
-);
+const BANNER_CONTENT = null;
 
 const Layout = ({ children, title }) => {
   const { site } = useStaticQuery(


### PR DESCRIPTION
Removes hiring banner stating that gnomAD is hiring a Computational Scientist, as this is no longer the case.

View a [preview here](https://gnomad.broadinstitute.org/news/preview/81/)