### PR TITLE
use pull_request_target so that dependabot prs work

### DIFF
--- a/.github/workflows/add_to_project.yml
+++ b/.github/workflows/add_to_project.yml
@@ -4,7 +4,7 @@ on:
   issues:
     types:
       - opened
-  pull_request:
+  pull_request_target:
     types:
       - opened
 


### PR DESCRIPTION
This switches the event type on the project/labeler action to use pull_request_target. This is an event type that causes PRs to run with a different set of permissions that grants them access to tokens, etc. I think this should be safe to do in cases where a code checkout is not happening, such as the labeler action.

More info on why this is needed here: https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/