### PR TITLE
Add eck update notice banner

### DIFF
--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -45,7 +45,7 @@ const Banner = styled.div`
   }
 `;
 
-const BANNER_CONTENT = null;
+const BANNER_CONTENT = `gnomAD will be undergoing maintenance on November 18th between 3-4PM EST. Search may be unavailable during that time.`;
 
 const Layout = ({ children, title }) => {
   const { site } = useStaticQuery(


### PR DESCRIPTION
One liner to update banner message ahead of the ECK update.

Corresponding `gnomad-browser` PR [here](https://github.com/broadinstitute/gnomad-browser/pull/1037).

[Preview here](https://gnomad.broadinstitute.org/news/preview/97/).