### PR TITLE
Remove eck update notice banner

### DIFF
--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -45,7 +45,7 @@ const Banner = styled.div`
   }
 `;
 
-const BANNER_CONTENT = `gnomAD will be undergoing maintenance on November 18th between 3-4PM EST. Search may be unavailable during that time.`;
+const BANNER_CONTENT = null;
 
 const Layout = ({ children, title }) => {
   const { site } = useStaticQuery(


### PR DESCRIPTION
One liner to remove the eck maintenance banner, to be merged once maintenance is complete later today.

Blog preview site [here](https://gnomad.broadinstitute.org/news/preview/98/).

Related browser PR [here](https://github.com/broadinstitute/gnomad-browser/pull/1040).