### PR TITLE
Add monoallelic variant flag to changelog

### DIFF
--- a/content/changelog/2022-11-monoallelic-variant-flag.md
+++ b/content/changelog/2022-11-monoallelic-variant-flag.md
@@ -1,0 +1,9 @@
+---
+title: Monoallelic flag added to variant table
+date: "2022-11-30"
+order: 1
+---
+
+The variant table displayed on Gene, Region, and Transcript pages now includes a possible 'Monoallelic' flag. This flag labels sites where all samples have homozygous alternate genotypes.
+
+<!-- end_excerpt -->


### PR DESCRIPTION
Related browser PR: https://github.com/broadinstitute/gnomad-browser/pull/1048

Link to preview of [updated changelog here](https://gnomad.broadinstitute.org/news/preview/99/changelog).

Adds a entry to the changelog noting addition of the `monoallelic` flag in the variant table.