### PR TITLE
Add automated slack notification for new PRs

### DIFF
--- a/.github/workflows/notify_slack_pr_open.yml
+++ b/.github/workflows/notify_slack_pr_open.yml
@@ -1,0 +1,30 @@
+name: Slack Pull Request Open Notification
+
+on:
+  pull_request:
+    types: [opened, reopened]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Notify slack pr open
+      env: 
+        SLACK_WEBHOOK_URL : ${{ secrets.SLACK_WEBHOOK_URL }}
+        PULL_REQUEST_NUMBER : ${{ github.event.pull_request.number }}
+        PULL_REQUEST_TITLE : ${{ github.event.pull_request.title }}
+        PULL_REQUEST_AUTHOR_NAME : ${{ github.event.pull_request.user.login }}
+        PULL_REQUEST_AUTHOR_ICON_URL : ${{ github.event.pull_request.user.avatar_url }}
+        PULL_REQUEST_URL : ${{ github.event.pull_request.html_url }}
+        PULL_REQUEST_BODY : ${{ github.event.pull_request.body }}
+        PULL_REQUEST_COMPARE_BRANCH_OWNER: ${{ github.event.pull_request.head.repo.owner.login }}
+        PULL_REQUEST_COMPARE_BRANCH_NAME : ${{ github.event.pull_request.head.ref }}
+        PULL_REQUEST_BASE_BRANCH_OWNER: ${{ github.event.pull_request.base.repo.owner.login }}
+        PULL_REQUEST_BASE_BRANCH_NAME : ${{ github.event.pull_request.base.ref }}
+        IS_SEND_HERE_MENTION : true # maybe?
+        MAKE_PRETTY : true
+        MAKE_COMPACT : false
+        IS_PR_FROM_FORK: false
+        # SEND_USER_ID_MENTIONS : ABCDE12345,AAABBBCCCC
+        # SEND_GROUP_ID_MENTIONS : GROUPIDDDD,GGGGROUPID
+      uses: jun3453/slack-pr-open-notification-action@v1.3.0


### PR DESCRIPTION
Resolves #87 

Adds a `.yml` file that uses [this GitHub action](https://github.com/marketplace/actions/slack-pr-open-notification) to make a post to a Slack channel whenever a new PR is opened in this repository. 

Sample of the post in a slack channel (here it just DM'd to me for testing purposes). The name has since been changed to `gnomad-blog-pr-bot` as that seems a bit more descriptive. Name, icon, target slack channel, etc can be [modified here](https://the-tgg.slack.com/apps/A0F7XDUAZ-incoming-webhooks?tab=settings&next_id=0).

---

![Screen Shot 2022-12-01 at 08 50 33](https://user-images.githubusercontent.com/59549713/205070305-beb8aab7-6241-4587-835a-c92ceff20100.jpg)

---

Here, a PR being opened is a standin for a preview being generated. As far as I can tell, if we want to get clever with it (only post a notification for relevant new content, and not random bug-fixes) we would want to do some clever branching (have a `content` branch that we merge any content PRs into, before merging that into main, or something like that). 

Not sure if this is worth it at this point, most of the PRs that happen here are content PRs anyways.

