### PR TITLE
Add Team Page update to changelog

### DIFF
--- a/content/changelog/2023-01-updated-team-page.md
+++ b/content/changelog/2023-01-updated-team-page.md
@@ -1,0 +1,9 @@
+---
+title: Update team page
+date: "2023-01-30"
+order: 1
+---
+
+The [team page](https://gnomad.broadinstitute.org/team) has been updated to include headshots and bios for gnomAD staff members.
+
+<!-- end_excerpt -->


### PR DESCRIPTION
Related: https://github.com/broadinstitute/gnomad-browser/issues/1065

Adds a changelog entry that documents the addition of Bios and Headshots of gnomAD staff 
members to the Team page.

To be merged (and production updated) when the Team page PR on browser is merged: https://github.com/broadinstitute/gnomad-browser/pull/1066

Link to preview: https://gnomad.broadinstitute.org/news/preview/106/changelog
Link to new changelog post in preview: https://gnomad.broadinstitute.org/news/preview/106/2023-01-updated-team-page/