### PR TITLE
Add Downloads page update to changelog

### DIFF
--- a/content/changelog/2023-02-updated-downloads-page.md
+++ b/content/changelog/2023-02-updated-downloads-page.md
@@ -1,0 +1,15 @@
+---
+title: Update downloads page
+date: "2023-02-15"
+order: 1
+---
+
+The gnomAD [Downloads Page](https://gnomad.broadinstitute.org/downloads) has been redesigned to make it easier to explore datasets released by the gnomAD production team and gnomAD-affiliated research groups. 
+
+<!-- end_excerpt -->
+
+Previously, our major releases (gnomAD v2, gnomAD v3, and ExAC) were organized under tabs that users would click to see which datasets were available for each release. This tab-based navigation scheme made it difficult to quickly understand the information hierarchy on the page. It also prevented users from searching the page using the standard internet browser search functionality (CTRL + F).
+
+Now, instead of tabs, the new layout features a table of contents on the righthand side. Users will have a better sense of what is available and can quickly jump to specific releases and datasets. To help maintain a sense of context, the table of contents synchronizes with the page position as the user scrolls. Since all text is on the same page, CTRL-F searching is now possible.
+
+Furthermore, the new Downloads Page attempts to distinguish which datasets are produced by the gnomAD production team ("Core Dataset") from downstream analyses carried out by affiliated research groups ("Secondary Analyses"). For example, our recently released [Genomic Constraint](https://gnomad.broadinstitute.org/downloads#v3-genomic-constraint) analysis falls into the latter category.


### PR DESCRIPTION
Related: https://github.com/broadinstitute/gnomad-browser/pull/1069


[Preview link](https://gnomad.broadinstitute.org/news/preview/108/changelog)
[Preview link](https://gnomad.broadinstitute.org/news/preview/108/2023-02-updated-downloads-page/) (Links directly to the changelog entry)

Adds a changelog entry for the update to the Downloads page. To be merged/pushed to production when the corresponding Browser PR gets merged.