### PR TITLE
Update order of links on NavBar

### DIFF
--- a/src/components/header.js
+++ b/src/components/header.js
@@ -35,8 +35,18 @@ const Header = ({ siteTitle }) => {
             </a>
           </li>
           <li className="nav-item">
+            <a className="nav-link" href="https://gnomad.broadinstitute.org/policies">
+              Policies
+            </a>
+          </li>
+          <li className="nav-item">
+            <a className="nav-link" href="https://gnomad.broadinstitute.org/publications">
+              Publications
+            </a>
+          </li>
+          <li className="nav-item">
             <Link className="nav-link" to="/">
-              News
+              Blog
             </Link>
           </li>
           <li className="nav-item">
@@ -50,23 +60,13 @@ const Header = ({ siteTitle }) => {
             </a>
           </li>
           <li className="nav-item">
-            <a className="nav-link" href="https://gnomad.broadinstitute.org/policies">
-              Policies
-            </a>
-          </li>
-          <li className="nav-item">
-            <a className="nav-link" href="https://gnomad.broadinstitute.org/publications">
-              Publications
-            </a>
-          </li>
-          <li className="nav-item">
             <a className="nav-link" href="https://gnomad.broadinstitute.org/feedback">
-              Feedback
+              Contact
             </a>
           </li>
           <li className="nav-item">
             <a className="nav-link" href="https://gnomad.broadinstitute.org/help">
-              Help
+              Help/FAQ
             </a>
           </li>
         </ul>


### PR DESCRIPTION
Currently, the order of the links on the NavBar/Header is:
- About, Team, News, Changelog, Downloads, Policies, Publications, Contact, Help

Per a project meeting, this Pull Request changes the order of these links to:
- About, Team, Policies, Publications, Blog (used to be News), Changelog, Downloads, Contact, Help/FAQ (used to be Help)


![Screenshot 2023-08-10 at 16 50 16](https://github.com/broadinstitute/gnomad-blog/assets/59549713/78eaf0b0-f108-46f9-a15b-2cfea7e2474b)

