### PR TITLE
Update modify population frequency changelog post

### DIFF
--- a/content/changelog/2023-08-modify-population-frequency-table.md
+++ b/content/changelog/2023-08-modify-population-frequency-table.md
@@ -1,5 +1,5 @@
 ---
-title: Allele frequency table display modified
+title: Population frequency display modified
 date: "2023-08-24"
 order: 1
 ---


### PR DESCRIPTION
Related browser PR: https://github.com/broadinstitute/gnomad-browser/pull/1162

Link to changelog preview for convenience: https://gnomad.broadinstitute.org/news/preview/126/changelog

Adds a changelog entry that briefly describes the minor update to the population frequencies table. With this change, the table displays a "`-`" character when the Allele Number is 0, rather than a 0.