### PR TITLE
Backfill changelog

### DIFF
--- a/content/changelog/2022-02-fix-variant-table-flags.md
+++ b/content/changelog/2022-02-fix-variant-table-flags.md
@@ -1,0 +1,13 @@
+---
+title: Fix OS variant table flag display
+date: "2023-02-02"
+order: 1
+---
+
+Previously, if a variant had an Other Splice loss of function flag as a consequence, the variant table would incorrectly display both a Low Confidence flag (LC pLoF), as well as the Other Splice flag (OS pLoF). 
+
+Now, in those cases, table only displays the Other Splice flag.
+
+<!-- end_excerpt -->
+
+

--- a/content/changelog/2023-03-add-favicon.md
+++ b/content/changelog/2023-03-add-favicon.md
@@ -1,0 +1,11 @@
+---
+title: Add favicon
+date: "2023-03-08"
+order: 1
+---
+
+A favicon has been added to the gnomAD browser. This will help users to distinguish which tabs are gnomAD at a glance. The favicon is styled like the coverage plot, showing coverage for both exomes and genomes.
+
+<!-- end_excerpt -->
+
+

--- a/content/changelog/2023-03-update-publications-page.md
+++ b/content/changelog/2023-03-update-publications-page.md
@@ -1,0 +1,13 @@
+---
+title: Update publications page
+date: "2023-03-17"
+order: 1
+---
+
+The publications page has been updated to include a more up to date list of publications, as well as to update the citation format to denote which authors contributed equally.
+
+With the update of the publications page, the citations topic on the help page has been removed. The citations topic URL now redirects to the updated publications page.
+
+<!-- end_excerpt -->
+
+

--- a/content/changelog/2023-04-add-back-to-gene-button.md
+++ b/content/changelog/2023-04-add-back-to-gene-button.md
@@ -1,0 +1,15 @@
+---
+title: Add gene page link on variant page
+date: "2023-03-17"
+order: 1
+---
+
+Previously, users that wanted to go to the corresponding gene page, from a variant page, would scroll down to the "Variant Effect Predictor" section of the variant page, and click on one of the gene links. In cases where many distinct variant pages were open, users expressed interest in a more direct way to go to the gene page.
+
+With this change, a button labeled "Gene" has been added to the header row of a variant page where there is a single canonical transcript. This button allows users to quickly navigate to the gene that the variant falls in. In the rare case where there is no single canonical transcript, there is no gene page button, and users should instead use the Variant Effect Predictor section.
+
+In order to accomodate the extra button, the phrase Single Nucleotide Variant has been abbreviated to SNV on the corresponding variant pages.
+
+<!-- end_excerpt -->
+
+

--- a/content/changelog/2023-05-update-api-to-typescript.md
+++ b/content/changelog/2023-05-update-api-to-typescript.md
@@ -1,0 +1,11 @@
+---
+title: Update GraphQL API to TypeScript
+date: "2023-05-19"
+order: 1
+---
+
+The gnomAD browser's public GraphQL API has had its language updated to TypeScript, from JavaScript. This update has been tested thoroughly and should represent no change in functionality or service.
+
+<!-- end_excerpt -->
+
+

--- a/content/changelog/2023-05-update-team-page.md
+++ b/content/changelog/2023-05-update-team-page.md
@@ -1,0 +1,9 @@
+---
+title: Update team page
+date: "2023-05-22"
+order: 1
+---
+
+The [team page](https://gnomad.broadinstitute.org/team) has been updated to reflect changes in gnomAD staff and council.
+
+<!-- end_excerpt -->

--- a/content/changelog/2023-06-update-to-es-7.md
+++ b/content/changelog/2023-06-update-to-es-7.md
@@ -1,0 +1,11 @@
+---
+title: Update to Elasticsearch 7
+date: "2023-06-20"
+order: 1
+---
+
+The gnomAD browser's backend database has had a major version update applied. It is now running Elasticsearch 7 and was previously running Elasticsearch 6. This update has been tested thoroughly and should represent no change in functionality or service.
+
+<!-- end_excerpt -->
+
+

--- a/content/changelog/2023-07-add-all-of-us-link.md
+++ b/content/changelog/2023-07-add-all-of-us-link.md
@@ -1,0 +1,11 @@
+---
+title: Add All of Us link on variant page
+date: "2023-07-17"
+order: 1
+---
+
+A link to the All of Us (AoU) data browser has been added to the variant pages under the "External resources" section. This lets users quickly navigate to the same variant on the AoU data browser.
+
+<!-- end_excerpt -->
+
+

--- a/content/changelog/2023-07-fix-coocurrence-table-datasets.md
+++ b/content/changelog/2023-07-fix-coocurrence-table-datasets.md
@@ -1,0 +1,13 @@
+---
+title: Fix co-occurrence table rendering on v3 datasets
+date: "2023-07-18"
+order: 1
+---
+
+Previously, the variant co-occurrence table on the gene page incorrectly rendered on v3 datasets. This was unintentional and misleading, as the analysis was not performed on v3.
+
+Now, the co-occurrence table only renders on v2 datasets, as intended.
+
+<!-- end_excerpt -->
+
+

--- a/content/changelog/2023-07-sort-gene-search-results.md
+++ b/content/changelog/2023-07-sort-gene-search-results.md
@@ -1,0 +1,15 @@
+---
+title: Change gene search results sorting
+date: "2023-07-10"
+order: 1
+---
+
+Previously, when a user searched for a gene, a gene that had an alternate symbol that closely matched the search term could appear first in the list of suggested gene symbols. This led to confusing behavior and the need to pay close attention to which results the search bar returned.
+
+Now, any gene with a canonical symbol that matches the search term is prioritized in the list of search results. This results in an overall more intuitive user experience when searching for genes by symbol.
+
+As an example, the search term ABCD previously would result in the gene CX3CL1 as the first search result, as ABCD-3 is an alternate symbol for CX3CL1. With this change, searching for ABCD now results in ABCD1 as the first search result, as it prioritizes canonical gene symbols.
+
+<!-- end_excerpt -->
+
+

--- a/content/changelog/2023-07-update-feedback-page.md
+++ b/content/changelog/2023-07-update-feedback-page.md
@@ -1,0 +1,11 @@
+---
+title: Update contact page
+date: "2023-07-18"
+order: 1
+---
+
+The contact page (previously the feedback page) has had its contents updated for clarity.
+
+<!-- end_excerpt -->
+
+

--- a/content/changelog/2023-07-update-interpretation-paper.md
+++ b/content/changelog/2023-07-update-interpretation-paper.md
@@ -1,0 +1,11 @@
+---
+title: Update variant interpretation paper
+date: "2023-07-31"
+order: 1
+---
+
+The link to the variant interpretation paper on the home page has been updated to a more recent publication.
+
+<!-- end_excerpt -->
+
+

--- a/content/changelog/2023-08-modify-nav-bar.md
+++ b/content/changelog/2023-08-modify-nav-bar.md
@@ -1,0 +1,13 @@
+---
+title: Modify navigation bar links
+date: "2023-08-11"
+order: 1
+---
+
+The ordering of the links on the navigation bar has been updated to reflect the frequency of their usage. The order of the links is now: About, Team, Policies, Publications, Blog, Changelog, Downloads, Help/FAQ.
+
+In addition, the link formerly titled "News" is now "Blog", and the link formerly titled "Help" is now titled "Help/FAQ".
+
+<!-- end_excerpt -->
+
+


### PR DESCRIPTION
Resolves: #128 

Preview link for convenience: https://gnomad.broadinstitute.org/news/preview/127/changelog

Adds entries to the changelog that were not catalogued. 

---

The criteria for adding something to the changelog for this PR was:

- user facing changes (re-ordering of links, changing referenced papers, bug fixes, functionality changes)
- major non-user facing changes (updating a language, major version update to database)


As such, these changelog additions **do not** include

- minor technical fixes (refactoring of bad design patterns)
- minor copy/content fixes (updating an old checksum for a download)

Let me know if this criteria should change, and changelog posts can be added or removed.

---

The changelog has been neglected for many months now (my bad). General practice surrounding adding to the changelog as browser changes happen will improve going forward.
