### PR TITLE
Add v4 launch banner

### DIFF
--- a/src/components/header.js
+++ b/src/components/header.js
@@ -35,6 +35,11 @@ const Header = ({ siteTitle }) => {
             </a>
           </li>
           <li className="nav-item">
+            <a className="nav-link" href="https://gnomad.broadinstitute.org/stats">
+              Stats
+            </a>
+          </li>
+          <li className="nav-item">
             <a className="nav-link" href="https://gnomad.broadinstitute.org/policies">
               Policies
             </a>
@@ -57,6 +62,11 @@ const Header = ({ siteTitle }) => {
           <li className="nav-item">
             <a className="nav-link" href="https://gnomad.broadinstitute.org/downloads">
               Downloads
+            </a>
+          </li>
+          <li className="nav-item">
+            <a className="nav-link" href="https://discuss.gnomad.broadinstitute.org/">
+              Forum
             </a>
           </li>
           <li className="nav-item">

--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -41,11 +41,17 @@ const Banner = styled.div`
   text-align: center;
 
   a {
-    color: #fff !important;
+    color: #8ac8f4 !important;
+    text-decoration: underline;
   }
 `;
 
-const BANNER_CONTENT = null;
+const BANNER_CONTENT = (
+  <>
+    gnomAD v4 is here! Read our {/* @ts-expect-error */}
+    <ExternalLink href="/news/2023-11-gnomad-v4-0">blog post</ExternalLink> for more details
+  </>
+);
 
 const Layout = ({ children, title }) => {
   const { site } = useStaticQuery(


### PR DESCRIPTION
Resolves https://github.com/broadinstitute/gnomad-browser/issues/1165

Corresponding Browser PR: https://github.com/broadinstitute/gnomad-browser/pull/1229

Adds a banner to the gnomAD Browser to better publicize the launch of gnomAD v4.

![Screenshot 2023-10-30 at 17 18 26](https://github.com/broadinstitute/gnomad-blog/assets/59549713/333eaeb2-24d5-407f-86dd-f197fb0c439d)

---

This PR also contains a commit that updates the gnomAD blog's header to stay in sync with the gnomAD browser's header (adds links to Stats and Forum).