### PR TITLE
Rename "V4" in CNV blog post to "v4" 

### DIFF
--- a/content/posts/2023-11-v4-copy-number-variants.md
+++ b/content/posts/2023-11-v4-copy-number-variants.md
@@ -1,5 +1,5 @@
 ---
-title: Rare coding CNVs from exome sequenced individuals in gnomAD V4
+title: Rare coding CNVs from exome sequenced individuals in gnomAD v4
 date: 2023-11-01
 order: 4
 categories:


### PR DESCRIPTION
This PR updates the title of the CNV blog post to change "V4" to "v4".

Fixes https://github.com/broadinstitute/gnomad-browser/issues/1263