### PR TITLE
Add changelog for v4 chrY exome VCF recopy

### DIFF
--- a/content/changelog/2023-11-v4-exome-chr-y-vcf-recopy.md
+++ b/content/changelog/2023-11-v4-exome-chr-y-vcf-recopy.md
@@ -1,5 +1,5 @@
 ---
-title: v4.0 exome's chromosome Y VCF fixed
+title: Fixed chromosome Y VCF for v4.0 exomes
 date: "2023-11-16"
 order: 1
 ---

--- a/content/changelog/2023-11-v4-exome-chr-y-vcf-recopy.md
+++ b/content/changelog/2023-11-v4-exome-chr-y-vcf-recopy.md
@@ -1,0 +1,9 @@
+---
+title: v4.0 exome's chromosome Y VCF fixed
+date: "2023-11-16"
+order: 1
+---
+
+The exome chromsome Y VCF that was originally released on November 1st, 2023 was a duplicate of the genome chromosome Y VCF. The duplicate has been replaced by the correct VCF as November 16th, 2023. 
+
+<!-- end_excerpt -->


### PR DESCRIPTION
A user recently reported  the exome and genome chrY VCFs were the same file. It looks like something wonky happened during a file transfer. The correct chrY file has been restaged but this should not be merged until the file is updated in gcp's public bucket. 

@rileyhgrant , I think this means the file size and MD5 needs to be updated for this file on the Downloads page? It is now 163.7 MB and `c8414744cf75fa498e2497a9391eb1ad`
```
gsutil hash -h gs://gnomad-public-requester-pays/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chrY.vcf.bgz

Hashes [hex] for release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chrY.vcf.bgz:
	Hash (md5):		c8414744cf75fa498e2497a9391eb1ad
	Hash (crc32c):		7eadc442
``` 
Also it looks like the current genomes chrY MD5 is incorrect as `MD5: b39443d98eeb5f6735aa57e37d378edf`. It should be  `8c231b75745b6670555915847c9999e8` 
```
gsutil hash -h gs://gcp-public-data--gnomad/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chrY.vcf.bgz

Hashes [hex] for release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chrY.vcf.bgz:
	Hash (md5):		8c231b75745b6670555915847c9999e8
	Hash (crc32c):		4b5875ee
```

@rileyhgrant , I created https://github.com/broadinstitute/gnomad-browser/pull/1296 with the additional  changes I think are required here but just wanted to confirm with you nothing else needs to be done!