### PR TITLE
switches gcloud authentication to new auth action

### DIFF
--- a/.github/workflows/build_preview.yml
+++ b/.github/workflows/build_preview.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   build-preview:
     runs-on: ubuntu-latest
+    permissions:
+      contents: 'read'
+      id-token: 'write'
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/build_preview.yml
+++ b/.github/workflows/build_preview.yml
@@ -57,12 +57,17 @@ jobs:
           pr_number=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
           PATH_PREFIX="/news/preview/${pr_number}" yarn run build
 
+      - name: gcloud auth
+        if: github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'
+        uses: google-github-actions/auth@v2
+        with:
+          # Format for this secret is: projects/123456789/locations/global/workloadIdentityPools/my-pool/providers/my-provider
+          workload_identity_provider: '${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}'
+          service_account: '${{ secrets.GCS_SA_EMAIL }}'
+
       - name: Setup gcloud
         if: github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'
-        uses: google-github-actions/setup-gcloud@v0.3
-        with:
-          service_account_email: ${{ secrets.GCS_SA_EMAIL }}
-          service_account_key: ${{ secrets.GCS_SA_KEY }}
+        uses: google-github-actions/setup-gcloud@v2
 
       - name: Deploy preview
         if: github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'

--- a/.github/workflows/delete_preview.yml
+++ b/.github/workflows/delete_preview.yml
@@ -7,6 +7,9 @@ jobs:
   delete-preview:
     if: github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login != 'dependabot[bot]'
     runs-on: ubuntu-latest
+    permissions:
+      contents: 'read'
+      id-token: 'write'
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/delete_preview.yml
+++ b/.github/workflows/delete_preview.yml
@@ -11,11 +11,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Setup gcloud
-        uses: google-github-actions/setup-gcloud@v0.3
+      - name: gcloud auth
+        uses: google-github-actions/auth@v2
         with:
-          service_account_email: ${{ secrets.GCS_SA_EMAIL }}
-          service_account_key: ${{ secrets.GCS_SA_KEY }}
+          # Format for this secret is: projects/123456789/locations/global/workloadIdentityPools/my-pool/providers/my-provider
+          workload_identity_provider: '${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}'
+          service_account: '${{ secrets.GCS_SA_EMAIL }}'
+
+      - name: Setup gcloud
+        uses: google-github-actions/setup-gcloud@v2
 
       - name: Delete preview
         run: |

--- a/.github/workflows/update_site.yml
+++ b/.github/workflows/update_site.yml
@@ -36,11 +36,15 @@ jobs:
         run: |
           PATH_PREFIX="/news" yarn run build
 
-      - name: Setup gcloud
-        uses: google-github-actions/setup-gcloud@v0.3
+      - name: gcloud auth
+        uses: google-github-actions/auth@v2
         with:
-          service_account_email: ${{ secrets.GCS_SA_EMAIL }}
-          service_account_key: ${{ secrets.GCS_SA_KEY }}
+          # Format for this secret is: projects/123456789/locations/global/workloadIdentityPools/my-pool/providers/my-provider
+          workload_identity_provider: '${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}'
+          service_account: '${{ secrets.GCS_SA_EMAIL }}'
+
+      - name: Setup gcloud
+        uses: google-github-actions/setup-gcloud@v2
 
       - name: Deploy site
         run: |

--- a/.github/workflows/update_site.yml
+++ b/.github/workflows/update_site.yml
@@ -6,6 +6,9 @@ on:
 jobs:
   update-site:
     runs-on: ubuntu-latest
+    permissions:
+      contents: 'read'
+      id-token: 'write'
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
The blog deploys by gsutil rsync'ing files to the GCS bucket, which requires authentication. Previously, we used a JSON service account key to authenticate, but google has deprecated that in favor of using workload identity federation for keyless authentication. This PR updates our GH actions workflows to auth with that new method.

PR is in draft state until the terraform PR which sets up workload identity federation is applied.

Closes #118