### PR TITLE
Fix incorrectly used date_format field

### DIFF
--- a/netlify-cms-config.yml
+++ b/netlify-cms-config.yml
@@ -32,7 +32,7 @@ collections:
         name: "date"
         widget: "datetime"
         format: "YYYY-MM-DD"
-        date_format: "MMMM DD, YYYY"
+        date_format: "YYYY-MM-DD"
         time_format: false
       - label: "Relative order"
         hint: "Order in which to display this post relative to other posts published on the same date."
@@ -67,7 +67,7 @@ collections:
         name: "date"
         widget: "datetime"
         format: "YYYY-MM-DD"
-        date_format: "MMMM DD, YYYY"
+        date_format: "YYYY-MM-DD"
         time_format: false
       - label: "Relative order"
         hint: "Order in which to display this post relative to other posts published on the same date."


### PR DESCRIPTION
With the change from netlify -> decap cms, the `date_format` field in the config file stopped behaving as it did before. 

With the update, the CMS started to incorrectly save a date selected via the CMS in the format specified by `date_format`, previously `date_format` was used to format the date shown by the date picker.

This PR changes the `date_format` field to the format expected by the app in the frontmatter, allowing blog posts / changelogs created within the CMS to have properly formatted frontmatter.

---

![Screenshot 2024-08-09 at 17 12 33](https://github.com/user-attachments/assets/ce50c771-265f-44f4-8276-aab1dd6f26bd)
