### PR TITLE
Bump deprecated cache action

### DIFF
--- a/.github/workflows/update_site.yml
+++ b/.github/workflows/update_site.yml
@@ -25,7 +25,7 @@ jobs:
         run: echo "::set-output name=dir::$(yarn cache dir)"
 
       - name: Use yarn cache
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ${{ steps.yarn-cache.outputs.dir }}
           key: yarn-${{ hashFiles('**/yarn.lock') }}


### PR DESCRIPTION
Bumps yarn cache from v1 to v4 in `update_site.yml`, as v1/v2 are now deprecated