### PR TITLE
Update v4 lai link

### DIFF
--- a/content/posts/2024-10-local-ancestry-inference-for-african-african-american-samples-in-gnomad.md
+++ b/content/posts/2024-10-local-ancestry-inference-for-african-african-american-samples-in-gnomad.md
@@ -51,3 +51,5 @@ By calculating and releasing LAI-informed data, we provide a higher-resolution v
 6. Lewis, A. C. F., Molina, S. J., Appelbaum, P. S., Dauda, B., Di Rienzo, A., Fuentes, A., Fullerton, S. M., Garrison, N. A., Ghosh, N., Hammonds, E. M., Jones, D. S., Kenny, E. E., Kraft, P., Lee, S. S., Mauro, M., Novembre, J., Panofsky, A., Sohail, M., Neale, B. M., & Allen, D. S. (2022). Getting genetic ancestry right for science and society. Science (New York, N.Y.), 376(6590), 250–252. <https://doi.org/10.1126/science.abm7530>
 
 \*These authors contributed equally to this work.
+
+*Updated in May 2025 to change the gnomAD downloadable file hyperlink target to reflect a minor reorganization*

--- a/content/posts/2024-10-local-ancestry-inference-for-african-african-american-samples-in-gnomad.md
+++ b/content/posts/2024-10-local-ancestry-inference-for-african-african-american-samples-in-gnomad.md
@@ -17,7 +17,7 @@ We have now released an extension of local ancestry-informed frequency work from
 
 <!-- end_excerpt -->
 
-The new local ancestry-informed frequency data includes 24,204,574 bi-allelic variants with low genotype missingness (call rate > 0.9) and an allele frequency greater than 0.1% within this genetic ancestry group. The dataset is accessible through the frequency tables on the variant pages in the browser and also as a [downloadable VCF](https://gnomad.broadinstitute.org/downloads#v4-local-ancestry). This release of gnomAD LAI-informed data provides alternate allele counts, allele numbers, and frequencies partitioned by continental genetic ancestries, with the extension of fine-scale ancestry resolution to the African/African American genetic ancestry group aiming to further improve the interpretation of genetic variation within admixed individuals.
+The new local ancestry-informed frequency data includes 24,204,574 bi-allelic variants with low genotype missingness (call rate > 0.9) and an allele frequency greater than 0.1% within this genetic ancestry group. The dataset is accessible through the frequency tables on the variant pages in the browser and also as a [downloadable VCF](https://gnomad.broadinstitute.org/downloads#v3-local-ancestry). This release of gnomAD LAI-informed data provides alternate allele counts, allele numbers, and frequencies partitioned by continental genetic ancestries, with the extension of fine-scale ancestry resolution to the African/African American genetic ancestry group aiming to further improve the interpretation of genetic variation within admixed individuals.
 
 #### Methods
 


### PR DESCRIPTION
Per https://github.com/broadinstitute/gnomad-browser/issues/1703

Related gnomad browser PR: https://github.com/broadinstitute/gnomad-browser/pull/1721

The v4 lai downloads are moved to the v3 header. This smol PR updates the link in this blogpost to point to the new location.