### PR TITLE
Update header to match gnomAD browser

### DIFF
--- a/src/components/header.js
+++ b/src/components/header.js
@@ -35,6 +35,11 @@ const Header = ({ siteTitle }) => {
             </a>
           </li>
           <li className="nav-item">
+            <a className="nav-link" href="https://gnomad.broadinstitute.org/federated">
+              Federated 
+            </a>
+          </li>
+          <li className="nav-item">
             <a className="nav-link" href="https://gnomad.broadinstitute.org/stats">
               Stats
             </a>
@@ -65,12 +70,17 @@ const Header = ({ siteTitle }) => {
             </a>
           </li>
           <li className="nav-item">
-            <a className="nav-link" href="https://discuss.gnomad.broadinstitute.org/">
+            <a 
+              className="nav-link" 
+              href="https://discuss.gnomad.broadinstitute.org/" 
+              target="_blank"
+              rel="noopener noreferrer"
+            >
               Forum
             </a>
           </li>
           <li className="nav-item">
-            <a className="nav-link" href="https://gnomad.broadinstitute.org/feedback">
+            <a className="nav-link" href="https://gnomad.broadinstitute.org/contact">
               Contact
             </a>
           </li>


### PR DESCRIPTION
Resolves: https://github.com/broadinstitute/gnomad-browser/issues/1864

The two apps headers had drifted apart, this makes 3 minor changes to make this gnomAD blog's header match the gnomAD browsers:
- Add '`federated`' nav link
- Update the '`forum`' nav link to open in new tab
- Update the '`contact`' nav link to go directly to `.../contact` (we have a redirect from `/feedback` -> `/contact`, but still, good to have it go directly go contact)